### PR TITLE
intg/dash gestor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,14 @@
         "react-router-dom": "^7.6.2",
         "recharts": "^2.15.3",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
+        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.4.1",
         "autoprefixer": "^10.4.17",
         "eslint": "^9.25.0",
@@ -2138,6 +2140,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.34.0",
@@ -5523,6 +5531,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "react-router-dom": "^7.6.2",
     "recharts": "^2.15.3",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.4.1",
     "autoprefixer": "^10.4.17",
     "eslint": "^9.25.0",

--- a/src/components/CollaboratorCard.tsx
+++ b/src/components/CollaboratorCard.tsx
@@ -8,7 +8,7 @@ interface CollaboratorCardProps {
   autoAssessment: number | null;
   assessment360?: number | null;
   managerScore: number | null;
-  finalScore?: number | "-";
+  finalScore?: number | "-" | null;
   gestorCard?: boolean;
   brutalFactsCard?: boolean;
   onClickArrow?: () => void;
@@ -33,10 +33,14 @@ const CollaboratorCard: React.FC<CollaboratorCardProps> = ({
 
   const getInitials = (fullName: string) => {
     const parts = fullName.trim().split(" ");
-    if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
-    return parts[0].charAt(0).toUpperCase() + parts[1].charAt(0).toUpperCase();
+    return parts
+      .slice(0, 2)
+      .map((p) => p.charAt(0).toUpperCase())
+      .join("");
   };
 
+  const formatScore = (score: number | null | undefined) =>
+    typeof score === "number" ? score.toFixed(1) : "-";
   return (
     <div className="flex items-center p-4 rounded-lg border border-gray-200 bg-white shadow-sm">
       <div className="flex items-center mr-6 min-w-[200px]">
@@ -61,51 +65,50 @@ const CollaboratorCard: React.FC<CollaboratorCardProps> = ({
             Autoavaliação
           </span>
           <span className="font-bold text-gray-800 text-sm inline-block bg-gray-100 px-2 py-0.5 rounded w-10 text-center">
-            {autoAssessment !== null ? autoAssessment.toFixed(1) : "-"}
+            {formatScore(autoAssessment)}
           </span>
         </div>
-        {gestorCard !== true && (
+
+        {!gestorCard && (
           <div className="flex items-center min-w-[140px] space-x-2">
             <span className="text-gray-500 text-sm whitespace-nowrap">
               Avaliação 360
             </span>
             <span className="font-bold text-gray-800 text-sm inline-block bg-gray-100 px-2 py-0.5 rounded w-10 text-center">
-              {assessment360 !== undefined && assessment360 !== null
-                ? assessment360.toFixed(1)
-                : "-"}
+              {formatScore(assessment360)}
             </span>
           </div>
         )}
+
         <div className="flex items-center min-w-[140px] space-x-2">
           <span className="text-gray-500 text-sm whitespace-nowrap">
             Nota gestor
           </span>
           <span className="font-bold text-gray-800 text-sm inline-block bg-gray-100 px-2 py-0.5 rounded w-10 text-center">
-            {managerScore !== null ? managerScore.toFixed(1) : "-"}
+            {formatScore(managerScore)}
           </span>
         </div>
-        {gestorCard !== true && (
+
+        {finalScore !== undefined && (
           <div className="flex items-center min-w-[140px] space-x-2">
             <span className="text-gray-500 text-sm whitespace-nowrap">
               Nota final
             </span>
             <span
               className={`font-bold text-sm inline-block px-2 py-0.5 rounded w-10 text-center ${
-                finalScore === "-" || finalScore === undefined
-                  ? "bg-gray-100 text-gray-800"
-                  : "text-white"
+                typeof finalScore === "number" &&
+                (gestorCard || brutalFactsCard)
+                  ? "text-white"
+                  : "bg-gray-100 text-gray-800"
               }`}
               style={
-                finalScore !== "-" &&
-                finalScore !== undefined &&
-                brutalFactsCard
+                typeof finalScore === "number" &&
+                (gestorCard || brutalFactsCard)
                   ? { backgroundColor: getColorByScore(finalScore) }
                   : {}
               }
             >
-              {finalScore === "-" || finalScore === undefined
-                ? "-"
-                : finalScore.toFixed(1)}
+              {typeof finalScore === "number" ? finalScore.toFixed(1) : "-"}
             </span>
           </div>
         )}
@@ -119,7 +122,6 @@ const CollaboratorCard: React.FC<CollaboratorCardProps> = ({
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               strokeLinecap="round"

--- a/src/components/CycleStatusCard.tsx
+++ b/src/components/CycleStatusCard.tsx
@@ -70,23 +70,13 @@ const CycleStatusCard = React.forwardRef<
     }
     variant = "soon";
   } else if (status === "finalizado") {
-    if (isGestor) {
-      title = `Ciclo de Avaliação ${nome} finalizado`;
-      description = (
-        <>
-          Resultados <span className="font-bold text-brand">disponíveis</span>
-        </>
-      );
-      variant = "results";
-    } else {
-      title = `Ciclo de Avaliação ${nome} finalizado`;
-      description = (
-        <>
-          Resultados <span className="font-bold text-brand">disponíveis</span>
-        </>
-      );
-      variant = "results";
-    }
+    title = `Ciclo de Avaliação ${nome} finalizado`;
+    description = (
+      <>
+        Resultados <span className="font-bold text-brand">disponíveis</span>
+      </>
+    );
+    variant = "results";
   }
 
   return (

--- a/src/components/CycleStatusCard.tsx
+++ b/src/components/CycleStatusCard.tsx
@@ -28,12 +28,13 @@ type CycleData = {
 
 type CycleStatusCardProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   ciclo: CycleData;
+  isGestor?: boolean;
 };
 
 const CycleStatusCard = React.forwardRef<
   HTMLButtonElement,
   CycleStatusCardProps
->(({ ciclo, className, ...props }, ref) => {
+>(({ ciclo, isGestor = false, className, ...props }, ref) => {
   const { nome, status, resultadosDisponiveis, diasRestantes } = ciclo;
 
   let title = "";
@@ -49,17 +50,43 @@ const CycleStatusCard = React.forwardRef<
     );
     variant = "default";
   } else if (status === "emRevisao") {
-    title = `Ciclo ${nome} em revisão`;
-    description = "Você pode avaliar seus liderados";
-    variant = "default";
-  } else if (status === "finalizado" && !resultadosDisponiveis) {
-    title = `Ciclo de Avaliação ${nome} finalizado`;
-    description = (
-      <>
-        Resultados disponíveis <span className="font-bold">em breve</span>
-      </>
-    );
+    if (isGestor) {
+      title = `Ciclo ${nome} em revisão`;
+      description = diasRestantes ? (
+        <>
+          <span className="font-bold">{diasRestantes}</span> dias restantes para
+          concluir suas avaliações
+        </>
+      ) : (
+        "Você pode avaliar seus liderados"
+      );
+    } else {
+      title = `Ciclo de Avaliação ${nome} finalizado`;
+      description = (
+        <>
+          Resultados disponíveis <span className="font-bold">em breve</span>
+        </>
+      );
+    }
     variant = "soon";
+  } else if (status === "finalizado" && !resultadosDisponiveis) {
+    if (isGestor) {
+      title = `Ciclo de Avaliação ${nome} finalizado`;
+      description = (
+        <>
+          Resultados <span className="font-bold text-brand">disponíveis</span>
+        </>
+      );
+      variant = "results";
+    } else {
+      title = `Ciclo de Avaliação ${nome} finalizado`;
+      description = (
+        <>
+          Resultados disponíveis <span className="font-bold">em breve</span>
+        </>
+      );
+      variant = "soon";
+    }
   } else if (status === "finalizado" && resultadosDisponiveis) {
     title = `Ciclo de Avaliação ${nome} finalizado`;
     description = (

--- a/src/components/CycleStatusCard.tsx
+++ b/src/components/CycleStatusCard.tsx
@@ -35,7 +35,7 @@ const CycleStatusCard = React.forwardRef<
   HTMLButtonElement,
   CycleStatusCardProps
 >(({ ciclo, isGestor = false, className, ...props }, ref) => {
-  const { nome, status, resultadosDisponiveis, diasRestantes } = ciclo;
+  const { nome, status, diasRestantes } = ciclo;
 
   let title = "";
   let description: React.ReactNode = "";
@@ -61,7 +61,7 @@ const CycleStatusCard = React.forwardRef<
         "Você pode avaliar seus liderados"
       );
     } else {
-      title = `Ciclo de Avaliação ${nome} finalizado`;
+      title = `Ciclo de Avaliação ${nome} em revisão`;
       description = (
         <>
           Resultados disponíveis <span className="font-bold">em breve</span>
@@ -69,7 +69,7 @@ const CycleStatusCard = React.forwardRef<
       );
     }
     variant = "soon";
-  } else if (status === "finalizado" && !resultadosDisponiveis) {
+  } else if (status === "finalizado") {
     if (isGestor) {
       title = `Ciclo de Avaliação ${nome} finalizado`;
       description = (
@@ -82,19 +82,11 @@ const CycleStatusCard = React.forwardRef<
       title = `Ciclo de Avaliação ${nome} finalizado`;
       description = (
         <>
-          Resultados disponíveis <span className="font-bold">em breve</span>
+          Resultados <span className="font-bold text-brand">disponíveis</span>
         </>
       );
-      variant = "soon";
+      variant = "results";
     }
-  } else if (status === "finalizado" && resultadosDisponiveis) {
-    title = `Ciclo de Avaliação ${nome} finalizado`;
-    description = (
-      <>
-        Resultados <span className="font-bold text-brand">disponíveis</span>
-      </>
-    );
-    variant = "results";
   }
 
   return (

--- a/src/components/DashboardStatCard.tsx
+++ b/src/components/DashboardStatCard.tsx
@@ -15,7 +15,8 @@ interface DashboardStatCardProps {
     | "currentScore"
     | "pendingReviews"
     | "growth"
-    | "evaluations";
+    | "evaluations"
+    | "managerReviews";
   title: string;
   description: string;
   icon?: ReactNode;
@@ -99,7 +100,6 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
                   ? value.toString().padStart(2, "0")
                   : value}
               </span>
-
             </div>
           </div>
         );
@@ -261,6 +261,34 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
         );
       }
 
+      case "managerReviews": {
+        const reviews = typeof value === "number" ? value : 0;
+        const color = "#dc2626";
+
+        return (
+          <div className={`${baseStyle} bg-white items-start`}>
+            <div className="flex-1 flex flex-col justify-start">
+              <p className="font-bold text-black text-lg sm:text-xl mb-5">
+                {title}
+              </p>
+              <p
+                className="text-text-muted text-sm border-l-4 pl-2"
+                style={{ borderColor: color }}
+              >
+                {description}
+              </p>
+            </div>
+            <div className="flex items-center ml-auto gap-2 mt-4 sm:mt-6">
+              <FilePen className="w-10 h-10" style={{ color }} />
+              <div className="flex flex-col items-start">
+                <span className="text-3xl font-bold" style={{ color }}>
+                  {reviews.toString().padStart(2, "0")}
+                </span>
+              </div>
+            </div>
+          </div>
+        );
+      }
       default:
         return null;
     }

--- a/src/components/DashboardStatCard.tsx
+++ b/src/components/DashboardStatCard.tsx
@@ -71,8 +71,9 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
                 : icon}
               <div className="flex flex-col items-start">
                 <span className="text-3xl font-bold" style={{ color }}>
-                  {score.toString().padStart(2, "0")}
+                  {score.toFixed(1)}
                 </span>
+
                 <span className="text-base font-semibold" style={{ color }}>
                   {label}
                 </span>

--- a/src/components/DashboardStatCard.tsx
+++ b/src/components/DashboardStatCard.tsx
@@ -24,6 +24,7 @@ interface DashboardStatCardProps {
   value?: string | number;
   prazoDias?: number;
   bgColor?: string;
+  onClick?: () => void;
 }
 
 const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
@@ -35,6 +36,7 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
   value,
   prazoDias = 0,
   bgColor,
+  onClick,
 }) => {
   const baseStyle = `w-full max-w-full min-h-[150px] rounded-2xl shadow-md p-4 sm:p-6 flex flex-col sm:flex-row justify-between sm:items-start gap-4 ${
     bgColor ??
@@ -108,7 +110,14 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
 
       case "equalizacoes": {
         return (
-          <div className={`${baseStyle} text-white items-start`}>
+          <div
+            className={`${baseStyle} text-white items-start ${
+              onClick
+                ? "cursor-pointer hover:opacity-90 transition-opacity"
+                : ""
+            }`}
+            onClick={onClick}
+          >
             <div className="flex-1 flex flex-col justify-start">
               <p className="font-bold text-white text-lg sm:text-xl mb-5">
                 {title}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ interface SidebarProps {
   role: Role;
   userName: string;
   onLogout: () => void;
+  cycleStatus?: "aberto" | "emRevisao" | "finalizado" | null;
 }
 
 const SECTIONS_BY_ROLE: Record<Role, SidebarSection[]> = {
@@ -48,12 +49,25 @@ const SECTIONS_BY_ROLE: Record<Role, SidebarSection[]> = {
   ],
 };
 
-export const Sidebar = ({ role, userName, onLogout }: SidebarProps) => {
-  const sections = SECTIONS_BY_ROLE[role];
+export const Sidebar = ({
+  role,
+  userName,
+  onLogout,
+  cycleStatus,
+}: SidebarProps) => {
+  const allSections = SECTIONS_BY_ROLE[role];
+
+  const sections =
+    role === "gestor"
+      ? allSections.filter(
+          (item) =>
+            item.label !== "Brutal Facts" || cycleStatus === "finalizado"
+        )
+      : allSections;
+
   const navigate = useNavigate();
 
   const handleLogout = () => {
-    // limpa o front
     onLogout();
     navigate("/", { replace: true });
   };

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "../components/Sidebar";
+/* import { useGestorDashboardData } from "@/pages/gestor/hooks/useGestorDashboardData"; */
 
 type Role = "colaborador" | "gestor" | "rh" | "comite";
 
@@ -10,9 +11,17 @@ interface LayoutProps {
 }
 
 export const Layout = ({ role, userName, onLogout }: LayoutProps) => {
+  /* const gestorData = useGestorDashboardData();
+  const cycleStatus = role === "gestor" ? gestorData.cycleStatus : null; */
+
   return (
     <div className="flex h-screen w-full overflow-hidden">
-      <Sidebar role={role} userName={userName} onLogout={onLogout} />
+      <Sidebar
+        role={role}
+        userName={userName}
+        onLogout={onLogout}
+        /*         cycleStatus={cycleStatus} */
+      />
       <main className="flex-1 bg-gray-100 overflow-y-auto">
         <Outlet />
       </main>

--- a/src/pages/gestor/Dashboard.tsx
+++ b/src/pages/gestor/Dashboard.tsx
@@ -3,173 +3,274 @@ import Avatar from "@/components/Avatar";
 import CycleStatusCard from "@/components/CycleStatusCard";
 import DashboardStatCard from "@/components/DashboardStatCard";
 import CollaboratorCard from "@/components/CollaboratorCard";
-import { Star, Users } from "lucide-react";
+import { Star, Users, FileText } from "lucide-react";
 import { Link } from "react-router-dom";
+import api from "@/api/api";
+import { useUser } from "@/contexts/UserContext";
 
 interface Collaborator {
-  id: number;
+  id: string;
   name: string;
   role: string;
   status: "Pendente" | "Finalizada";
   autoAssessment: number | null;
   managerScore: number | null;
+  finalScore: number | null;
+  selfDone: boolean;
 }
 
+interface Cycle {
+  id: string;
+  name: string;
+  endDate: string;
+  reviewDate: string;
+}
+
+type CycleStatus = "aberto" | "emRevisao" | "finalizado";
+
+const getCycleStatus = (cycle: Cycle): CycleStatus => {
+  const now = new Date();
+  const end = new Date(cycle.endDate);
+  const review = new Date(cycle.reviewDate);
+
+  if (now < review) return "aberto";
+  if (now >= review && now < end) return "emRevisao";
+  return "finalizado";
+};
+
+const daysLeft = (reviewDate: string): number => {
+  const end = new Date(reviewDate);
+  const today = new Date();
+  const diffTime = end.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return diffDays > 0 ? diffDays : 0;
+};
+
 const DashboardGestor = () => {
+  const { userName, userId } = useUser();
   const [collaborators, setCollaborators] = useState<Collaborator[]>([]);
+  const [cycle, setCycle] = useState<Cycle | null>(null);
+  const [currentScore, setCurrentScore] = useState<number>(0);
+  const [cycleStatus, setCycleStatus] = useState<CycleStatus | null>(null);
 
   useEffect(() => {
-    const data: Omit<Collaborator, "status">[] = [
-      {
-        id: 1,
-        name: "Maria",
-        role: "Developer",
-        autoAssessment: 4.0,
-        managerScore: null,
-      },
-      {
-        id: 2,
-        name: "Ylson",
-        role: "Developer",
-        autoAssessment: 5.0,
-        managerScore: 4.8,
-      },
-      {
-        id: 3,
-        name: "Ana",
-        role: "Developer",
-        autoAssessment: 4.0,
-        managerScore: 5.0,
-      },
-      {
-        id: 4,
-        name: "Maria",
-        role: "Developer",
-        autoAssessment: 4.0,
-        managerScore: null,
-      },
-      {
-        id: 5,
-        name: "Ylson",
-        role: "Developer",
-        autoAssessment: 5.0,
-        managerScore: 4.8,
-      },
-      {
-        id: 6,
-        name: "Ana",
-        role: "Developer",
-        autoAssessment: 4.0,
-        managerScore: 5.0,
-      },
-      {
-        id: 7,
-        name: "Maria",
-        role: "Developer",
-        autoAssessment: 4.0,
-        managerScore: null,
-      },
-      {
-        id: 8,
-        name: "Ylson",
-        role: "Developer",
-        autoAssessment: 5.0,
-        managerScore: 4.8,
-      },
-      {
-        id: 9,
-        name: "Ana",
-        role: "Developer",
-        autoAssessment: 4.0,
-        managerScore: 5.0,
-      },
-      {
-        id: 10,
-        name: "Maria",
-        role: "Developer",
-        autoAssessment: 4.0,
-        managerScore: null,
-      },
-      {
-        id: 11,
-        name: "Ylson",
-        role: "Developer",
-        autoAssessment: 5.0,
-        managerScore: 4.8,
-      },
-      {
-        id: 12,
-        name: "Ana",
-        role: "Developer",
-        autoAssessment: 4.0,
-        managerScore: 5.0,
-      },
-    ];
+    const fetchData = async () => {
+      try {
+        const res = await api.get<{
+          ciclo_atual_ou_ultimo: Cycle;
+          usuarios: {
+            id: string;
+            name: string;
+            role: string;
+            managerId: string;
+            scorePerCycle: {
+              cycleId: string;
+              selfScore: number | null;
+              leaderScore: number | null;
+              finalScore: number | null;
+            }[];
+          }[];
+        }>("/users");
 
-    const enriched = data.map((c) => {
-      const complete = c.managerScore !== null;
+        const { ciclo_atual_ou_ultimo, usuarios } = res.data;
+        const status = getCycleStatus(ciclo_atual_ou_ultimo);
 
-      const status: "Pendente" | "Finalizada" = complete
-        ? "Finalizada"
-        : "Pendente";
+        const filtered = usuarios.filter(
+          (u) => u.managerId === userId && u.role === "COLABORADOR"
+        );
 
-      return { ...c, status };
-    });
+        const enriched = filtered.map((u) => {
+          const score = u.scorePerCycle.find(
+            (s) => s.cycleId === ciclo_atual_ou_ultimo.id
+          ) || { selfScore: null, leaderScore: null, finalScore: null };
 
-    setCollaborators(enriched);
-  }, []);
+          const selfDone = score.selfScore !== null;
+          const managerDone = score.leaderScore !== null;
 
-  const currentScore = 4.5;
+          let statusText: "Pendente" | "Finalizada" = "Pendente";
 
-  const preenchimento = Math.round(
-    (collaborators.filter((c) => c.status === "Finalizada").length /
-      collaborators.length) *
-      100
-  );
+          if (status === "aberto" && selfDone) {
+            statusText = "Finalizada";
+          } else if (status === "emRevisao" && managerDone) {
+            statusText = "Finalizada";
+          } else if (status === "finalizado" && selfDone && managerDone) {
+            statusText = "Finalizada";
+          }
 
-  const pendentes = collaborators.filter((c) => c.status === "Pendente").length;
+          return {
+            id: u.id,
+            name: u.name,
+            role: u.role,
+            autoAssessment: score.selfScore ?? null,
+            managerScore: score.leaderScore ?? null,
+            finalScore:
+              status === "finalizado" && score.finalScore !== null
+                ? score.finalScore
+                : "-",
+            status: statusText,
+            selfDone,
+          };
+        });
+
+        setCollaborators(enriched);
+
+        const scoreList =
+          status === "finalizado"
+            ? enriched
+                .map((c) => c.finalScore)
+                .filter((v): v is number => v !== null)
+            : enriched
+                .map((c) => c.managerScore)
+                .filter((v): v is number => v !== null);
+
+        const average = scoreList.length
+          ? scoreList.reduce((a, b) => a + b, 0) / scoreList.length
+          : 0;
+
+        setCurrentScore(Number(average.toFixed(1)));
+        setCycle({ ...ciclo_atual_ou_ultimo });
+        setCycleStatus(status);
+      } catch (err) {
+        console.error("Erro ao carregar dados do dashboard do gestor", err);
+      }
+    };
+
+    fetchData();
+  }, [userId]);
+
+  const total = collaborators.length || 1;
+  const selfEvaluated = collaborators.filter((c) => c.selfDone).length;
+  const managerEvaluated = collaborators.filter(
+    (c) => c.managerScore !== null
+  ).length;
+
+  const selfEvaluationRate = Math.round((selfEvaluated / total) * 100);
+  const pendingSelfEvaluations = total - selfEvaluated;
+  const pendingManagerEvaluations = total - managerEvaluated;
+
+  const formatPendingText = (
+    qtd: number,
+    singular: string,
+    plural: string,
+    none: string
+  ) => {
+    if (qtd === 0) return none;
+    if (qtd === 1) return singular;
+    return plural.replace("{X}", qtd.toString());
+  };
 
   return (
     <div className="flex flex-col h-full p-6">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-xl text-text-primary">
-          <span className="font-bold">Olá,</span> Gestor
+          <span className="font-bold">Olá,</span> {userName}
         </h1>
-        <Avatar name="Gestor Nome" />
+        <Avatar name={userName} />
       </div>
 
       <div className="flex flex-col gap-4">
-        <CycleStatusCard
-          ciclo={{
-            nome: "2025.1",
-            status: "finalizado",
-            resultadosDisponiveis: true,
-          }}
-        />
+        {cycle && cycleStatus && (
+          <CycleStatusCard
+            ciclo={{
+              nome: cycle.name,
+              status: cycleStatus,
+              diasRestantes:
+                cycleStatus === "aberto"
+                  ? daysLeft(cycle.reviewDate)
+                  : undefined,
+            }}
+            isGestor
+          />
+        )}
 
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-3 mb-4">
-          <DashboardStatCard
-            type="currentScore"
-            title="Nota atual"
-            description="Nota final do ciclo realizado em 2024.2."
-            value={currentScore}
-            icon={<Star className="w-10 h-10" />}
-          />
-
-          <DashboardStatCard
-            type="preenchimento"
-            title="Preenchimento"
-            description={`Você preencheu ${preenchimento}% das suas avaliações de gestor.`}
-            progress={preenchimento}
-          />
-
-          <DashboardStatCard
-            type="equalizacoes"
-            title="Revisões pendentes"
-            description="Conclua suas revisões de nota"
-            value={pendentes}
-            icon={<Users className="w-10 h-10" />}
-          />
+          {cycleStatus === "aberto" && (
+            <>
+              <DashboardStatCard
+                type="currentScore"
+                title="Nota atual"
+                description={`Nota consolidada dos ciclos anteriores.`}
+                value={currentScore}
+                icon={<Star className="w-10 h-10" />}
+              />
+              <DashboardStatCard
+                type="preenchimento"
+                title="Preenchimento"
+                description={`${selfEvaluationRate}% dos colaboradores já concluíram suas avaliações.`}
+                progress={selfEvaluationRate}
+              />
+              <DashboardStatCard
+                type="managerReviews"
+                title="Avaliações pendentes"
+                description={formatPendingText(
+                  pendingSelfEvaluations,
+                  "1 colaborador ainda não concluiu as avaliações.",
+                  "{X} colaboradores ainda não concluíram as avaliações.",
+                  "Nenhum colaborador com avaliações pendentes."
+                )}
+                value={pendingSelfEvaluations}
+              />
+            </>
+          )}
+          {cycleStatus === "emRevisao" && (
+            <>
+              <DashboardStatCard
+                type="currentScore"
+                title="Nota atual"
+                description={`Nota parcial do ciclo ${cycle?.name}`}
+                value={currentScore}
+                icon={<Star className="w-10 h-10" />}
+              />
+              <DashboardStatCard
+                type="managerReviews"
+                title="Avaliações pendentes"
+                description={formatPendingText(
+                  pendingManagerEvaluations,
+                  "1 colaborador aguarda avaliação do gestor.",
+                  "{X} colaboradores aguardam avaliação do gestor.",
+                  "Nenhum colaborador aguarda avaliação do gestor."
+                )}
+                value={pendingManagerEvaluations}
+                icon={<Users className="w-10 h-10" />}
+              />
+              <DashboardStatCard
+                type="equalizacoes"
+                title="Revisões pendentes"
+                description={formatPendingText(
+                  pendingManagerEvaluations,
+                  "1 revisão ainda está pendente.",
+                  "{X} revisões ainda estão pendentes.",
+                  "Nenhuma revisão pendente."
+                )}
+                value={pendingManagerEvaluations}
+                icon={<Users className="w-10 h-10" />}
+              />
+            </>
+          )}
+          {cycleStatus === "finalizado" && (
+            <>
+              <DashboardStatCard
+                type="currentScore"
+                title="Nota atual"
+                description={`Nota final do ciclo realizado em ${cycle?.name}.`}
+                value={currentScore}
+                icon={<Star className="w-10 h-10" />}
+              />
+              <DashboardStatCard
+                type="growth"
+                title="Desempenho dos liderados"
+                description="Crescimento de +0.3 comparação ao ciclo 2024.1"
+                value={collaborators.length}
+              />
+              <DashboardStatCard
+                type="equalizacoes"
+                title="Brutal Facts"
+                description="Veja o desempenho de seus liderados"
+                value="-"
+                icon={<FileText className="w-10 h-10" />}
+              />
+            </>
+          )}
         </div>
 
         <div className="bg-white p-6 rounded-lg shadow-md">
@@ -184,11 +285,10 @@ const DashboardGestor = () => {
               Ver mais
             </Link>
           </div>
-
           <div className="space-y-4">
-            {collaborators.map((collaborator, index) => (
+            {collaborators.map((collaborator) => (
               <CollaboratorCard
-                key={index}
+                key={collaborator.id}
                 {...collaborator}
                 gestorCard={true}
               />

--- a/src/pages/gestor/Dashboard.tsx
+++ b/src/pages/gestor/Dashboard.tsx
@@ -57,6 +57,7 @@ const DashboardGestor = () => {
                   : undefined,
               resultadosDisponiveis: true,
             }}
+            isGestor
           />
         )}
 

--- a/src/pages/gestor/hooks/useGestorDashboardData.ts
+++ b/src/pages/gestor/hooks/useGestorDashboardData.ts
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import api from "@/api/api";
+import { useUser } from "@/contexts/UserContext";
+import { getCycleStatus } from "@/utils/getCycleStatus";
+import { calcularGrowth } from "@/utils/growthUtil";
+import type {
+  Collaborator,
+  Cycle,
+  CycleStatus,
+  RawUser,
+  ScorePerCycle,
+} from "@/types/gestor";
+
+export const useGestorDashboardData = () => {
+  const { userId } = useUser();
+  const [collaborators, setCollaborators] = useState<Collaborator[]>([]);
+  const [cycle, setCycle] = useState<Cycle | null>(null);
+  const [cycleStatus, setCycleStatus] = useState<CycleStatus | null>(null);
+  const [currentScore, setCurrentScore] = useState<number>(0);
+  const [growth, setGrowth] = useState<number>(0);
+  const [hasGrowthData, setHasGrowthData] = useState<boolean>(false);
+  const [growthBaseCount, setGrowthBaseCount] = useState<number>(0);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await api.get<{
+          ciclo_atual_ou_ultimo: Cycle | Cycle[];
+          usuarios: RawUser[];
+        }>(`/users/${userId}/subordinates`);
+
+        const { ciclo_atual_ou_ultimo, usuarios } = res.data;
+        const ultimoCiclo = Array.isArray(ciclo_atual_ou_ultimo)
+          ? ciclo_atual_ou_ultimo.sort(
+              (a, b) =>
+                new Date(b.endDate).getTime() - new Date(a.endDate).getTime()
+            )[0]
+          : ciclo_atual_ou_ultimo;
+
+        const status = getCycleStatus(ultimoCiclo);
+        const filtered = usuarios.filter(
+          (u) => u.managerId === userId && u.role === "COLABORADOR"
+        );
+
+        const enriched = filtered.map((u) => {
+          const score: Partial<ScorePerCycle> =
+            u.scorePerCycle.find((s) => s.cycleId === ultimoCiclo.id) || {};
+
+          const selfDone = score.selfScore !== null;
+          const managerDone = score.leaderScore !== null;
+
+          let statusText: "Pendente" | "Finalizada" = "Pendente";
+          if (status === "aberto" && selfDone) statusText = "Finalizada";
+          else if (status === "emRevisao" && managerDone)
+            statusText = "Finalizada";
+          else if (status === "finalizado" && selfDone && managerDone)
+            statusText = "Finalizada";
+
+          return {
+            id: u.id,
+            name: u.name,
+            role: u.role,
+            position: u.position.name,
+            autoAssessment: score.selfScore ?? null,
+            managerScore: score.leaderScore ?? null,
+            comiteScore: score.finalScore ?? null,
+            status: statusText,
+            allScores: u.scorePerCycle,
+            selfDone,
+          };
+        });
+
+        const { growth, hasGrowthData, growthBaseCount } = calcularGrowth(
+          enriched,
+          ultimoCiclo.id
+        );
+        setGrowth(growth);
+        setHasGrowthData(hasGrowthData);
+        setGrowthBaseCount(growthBaseCount);
+
+        const scoreList =
+          status === "finalizado"
+            ? enriched
+                .map((c) => c.comiteScore)
+                .filter((v): v is number => v !== null)
+            : enriched
+                .map((c) => c.managerScore)
+                .filter((v): v is number => v !== null);
+
+        const average = scoreList.length
+          ? scoreList.reduce((a, b) => a + b, 0) / scoreList.length
+          : 0;
+
+        setCurrentScore(Number(average.toFixed(1)));
+        setCollaborators(enriched);
+        setCycle(ultimoCiclo);
+        setCycleStatus(status);
+      } catch (err) {
+        console.error("Erro ao carregar dados do dashboard do gestor", err);
+      }
+    };
+
+    fetchData();
+  }, [userId]);
+
+  return {
+    collaborators,
+    cycle,
+    cycleStatus,
+    currentScore,
+    growth,
+    hasGrowthData,
+    growthBaseCount,
+  };
+};

--- a/src/types/gestor.ts
+++ b/src/types/gestor.ts
@@ -1,0 +1,38 @@
+export interface Collaborator {
+  id: string;
+  name: string;
+  role: string;
+  position: string;
+  status: "Pendente" | "Finalizada";
+  autoAssessment: number | null;
+  managerScore: number | null;
+  comiteScore: number | null;
+  selfDone: boolean;
+  allScores: ScorePerCycle[];
+}
+
+export interface Cycle {
+  id: string;
+  name: string;
+  endDate: string;
+  reviewDate: string;
+}
+
+export type CycleStatus = "aberto" | "emRevisao" | "finalizado";
+
+export interface ScorePerCycle {
+  cycleId: string;
+  selfScore: number | null;
+  leaderScore: number | null;
+  finalScore: number | null;
+  createdAt: string;
+}
+
+export interface RawUser {
+  id: string;
+  name: string;
+  role: string;
+  position: { name: string };
+  managerId: string;
+  scorePerCycle: ScorePerCycle[];
+}

--- a/src/utils/daysLeft.ts
+++ b/src/utils/daysLeft.ts
@@ -1,0 +1,7 @@
+export const daysLeft = (reviewDate: string): number => {
+  const end = new Date(reviewDate);
+  const today = new Date();
+  const diffTime = end.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return diffDays > 0 ? diffDays : 0;
+};

--- a/src/utils/formatPendingText.ts
+++ b/src/utils/formatPendingText.ts
@@ -1,0 +1,10 @@
+export const formatPendingText = (
+  qtd: number,
+  singular: string,
+  plural: string,
+  none: string
+): string => {
+  if (qtd === 0) return none;
+  if (qtd === 1) return singular;
+  return plural.replace("{X}", qtd.toString());
+};

--- a/src/utils/getCycleStatus.ts
+++ b/src/utils/getCycleStatus.ts
@@ -1,0 +1,11 @@
+import type { Cycle, CycleStatus } from "../types/gestor";
+
+export const getCycleStatus = (cycle: Cycle): CycleStatus => {
+  const now = new Date();
+  const end = new Date(cycle.endDate);
+  const review = new Date(cycle.reviewDate);
+
+  if (now < review) return "aberto";
+  if (now >= review && now < end) return "emRevisao";
+  return "finalizado";
+};

--- a/src/utils/growthUtil.ts
+++ b/src/utils/growthUtil.ts
@@ -1,0 +1,47 @@
+interface Score {
+  cycleId: string;
+  finalScore: number | null;
+  createdAt: string;
+}
+
+export function calcularGrowth(
+  colaboradores: { allScores: Score[] }[],
+  cicloAtualId: string
+): {
+  growth: number;
+  hasGrowthData: boolean;
+  growthBaseCount: number;
+} {
+  const atual: number[] = [];
+  const anterior: number[] = [];
+
+  colaboradores.forEach((colab) => {
+    const atualScore = colab.allScores.find((s) => s.cycleId === cicloAtualId);
+    const anteriorScore = colab.allScores
+      .filter((s) => s.cycleId !== cicloAtualId)
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      )[0];
+
+    if (atualScore?.finalScore != null && anteriorScore?.finalScore != null) {
+      atual.push(atualScore.finalScore);
+      anterior.push(anteriorScore.finalScore);
+    }
+  });
+
+  const avg = (arr: number[]) =>
+    arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
+
+  const base = colaboradores.filter(
+    (c) => c.allScores.filter((s) => s.finalScore !== null).length >= 2
+  ).length;
+
+  const growth = avg(atual) - avg(anterior);
+
+  return {
+    growth: Number(growth.toFixed(1)),
+    hasGrowthData: base > 0,
+    growthBaseCount: base,
+  };
+}


### PR DESCRIPTION
this pr connects the dashboardgestor component to real backend data. main updates:

-     fetches current or last cycle from /users/:userId/subordinates
-     maps collaborators' scores and statuses based on cycle stage (open, in review, finalized)
-     shows conditional dashboard cards (self-evaluation, manager reviews, growth, etc.)
-     renders collaborator cards with self, manager, and final scores

**how to test:**
1.   run the backend locally (npm run start:dev or similar)
2.   log in as a gestor (carlos@example.com 123)
3.   manually update cycle dates in the database to simulate:
   - an open cycle
   - a cycle in review
   - a finalized cycle
4.  confirm that:
  - dashboard updates correctly based on cycle stage
  - stats and collaborator data are accurate
  - brutal facts card appears only when cycle is finalized
