### PR TITLE
intg/colab results

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2",
+    "react-spinners": "^0.17.0",
     "recharts": "^2.15.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zustand": "^5.0.6",
     "uuid": "^11.1.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
+      framer-motion:
+        specifier: ^12.23.0
+        version: 12.23.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       lucide-react:
         specifier: ^0.514.0
         version: 0.514.0(react@19.1.0)
@@ -62,6 +65,9 @@ importers:
       react-router-dom:
         specifier: ^7.6.2
         version: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-spinners:
+        specifier: ^0.17.0
+        version: 0.17.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       recharts:
         specifier: ^2.15.3
         version: 2.15.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1469,6 +1475,20 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  framer-motion@12.23.0:
+    resolution: {integrity: sha512-xf6NxTGAyf7zR4r2KlnhFmsRfKIbjqeBupEDBAaEtVIBJX96sAon00kMlsKButSIRwPSHjbRrAPnYdJJ9kyhbA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1695,6 +1715,12 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  motion-dom@12.22.0:
+    resolution: {integrity: sha512-ooH7+/BPw9gOsL9VtPhEJHE2m4ltnhMlcGMhEqA0YGNhKof7jdaszvsyThXI6LVIKshJUZ9/CP6HNqQhJfV7kw==}
+
+  motion-utils@12.19.0:
+    resolution: {integrity: sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1920,6 +1946,12 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-spinners@0.17.0:
+    resolution: {integrity: sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -3536,6 +3568,15 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  framer-motion@12.23.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      motion-dom: 12.22.0
+      motion-utils: 12.19.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   fsevents@2.3.3:
     optional: true
 
@@ -3722,6 +3763,12 @@ snapshots:
       brace-expansion: 2.0.2
 
   minipass@7.1.2: {}
+
+  motion-dom@12.22.0:
+    dependencies:
+      motion-utils: 12.19.0
+
+  motion-utils@12.19.0: {}
 
   ms@2.1.3: {}
 
@@ -3911,6 +3958,11 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-transition-group: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
+  react-spinners@0.17.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-style-singleton@2.2.3(@types/react@19.1.8)(react@19.1.0):
     dependencies:

--- a/src/components/evaluation/FinalEvaluationCollapse.tsx
+++ b/src/components/evaluation/FinalEvaluationCollapse.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import {
   Accordion,
   AccordionContent,
@@ -10,27 +9,14 @@ import { StarRating } from "./StarRating";
 interface CriterionCollapseProps {
   title: string;
   score: number | null;
-  finalScore: number | null;
   justification: string;
-  onFilledChange?: (isFilled: boolean) => void;
 }
 
 const FinalEvaluationCollapse = ({
   title,
-  onFilledChange,
   score,
-  finalScore,
   justification = "",
 }: CriterionCollapseProps) => {
-  const isFilled = score !== null && justification.trim().length > 0;
-
-  useEffect(() => {
-    if (onFilledChange) {
-      onFilledChange(isFilled);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFilled]);
-
   return (
     <Accordion type="single" collapsible>
       <AccordionItem value="item-1">
@@ -45,11 +31,6 @@ const FinalEvaluationCollapse = ({
                   {score?.toFixed(1)}
                 </p>
               )}
-              {finalScore && (
-                <p className="px-2 py-1 rounded-md text-brand font-bold text-xs">
-                  {finalScore?.toFixed(1)}
-                </p>
-              )}
             </div>
           </div>
         </AccordionTrigger>
@@ -58,11 +39,6 @@ const FinalEvaluationCollapse = ({
             <div className="flex flex-col gap-2">
               <p>Sua avaliação de 1 à 5 com base no critério</p>
               <StarRating value={score ?? 0} disableHover lowOpacity />
-            </div>
-            <div className="self-stretch w-0.5 bg-gray-300 mx-4" />
-            <div className="flex flex-col gap-2">
-              <p>Avaliação Final</p>
-              <StarRating value={finalScore ?? undefined} disableHover />
             </div>
           </div>
           <div className="flex flex-col gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -47,7 +47,6 @@ button {
   cursor: pointer;
 }
 
-button:focus,
 button:focus-visible {
   outline: none !important;
   box-shadow: none !important;

--- a/src/pages/colaborador/Evaluations.tsx
+++ b/src/pages/colaborador/Evaluations.tsx
@@ -61,6 +61,9 @@ const Evaluations = () => {
   const [reference, setReference] = useState<Colaborator | null>(null);
   const [mentorData, setMentorData] = useState<Colaborator | null>(null);
   const [allColaborators, setAllColaborators] = useState<Colaborator[]>([]);
+  const [allColaboratorsWithMentor, setAllColaboratorsWithMentor] = useState<
+    Colaborator[]
+  >([]);
   const [filteredColaborators, setFilteredColaborators] = useState<
     Colaborator[]
   >([]);
@@ -261,18 +264,25 @@ const Evaluations = () => {
     async function fetchColaborators() {
       try {
         const response = await api.get(`/avaliacao-360/team-members`);
-        const colaborators: Colaborator[] = response.data.members
-          .filter((c: { id: string }) => c.id !== mentorData?.id)
-          .map(
-            (c: { id: string; name: string; position: { name: string } }) => ({
-              id: c.id,
-              name: c.name,
-              position: c.position.name,
-            })
-          );
+        const allMembers: Colaborator[] = response.data.members.map(
+          (c: { id: string; name: string; position: { name: string } }) => ({
+            id: c.id,
+            name: c.name,
+            position: c.position.name,
+          })
+        );
 
-        setAllColaborators(colaborators);
-        setFilteredColaborators(colaborators);
+        // Para avaliação 360: sem mentor
+        const colaboratorsWithoutMentor = allMembers.filter(
+          (c) => c.id !== mentorData?.id
+        );
+
+        // Para referências: com mentor
+        const colaboratorsWithMentor = allMembers;
+
+        setAllColaborators(colaboratorsWithoutMentor);
+        setAllColaboratorsWithMentor(colaboratorsWithMentor);
+        setFilteredColaborators(colaboratorsWithoutMentor);
       } catch {
         console.error("Erro ao buscar colaboradores");
       }
@@ -498,7 +508,7 @@ const Evaluations = () => {
       {activeTab === "referências" && (
         <div className="flex flex-col p-6 gap-6">
           <SearchColaborators
-            colaborators={allColaborators}
+            colaborators={allColaboratorsWithMentor}
             selected={reference}
             setSelected={handleSelectReference}
           />

--- a/src/pages/colaborador/Evaluations.tsx
+++ b/src/pages/colaborador/Evaluations.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
   SelectContent,
 } from "@/components/ui/select";
+import { MoonLoader } from "react-spinners";
 
 interface Criterion {
   id: string;
@@ -359,7 +360,11 @@ const Evaluations = () => {
   }, [results, selectedCycleId]);
 
   if (!variant) {
-    return <div className="p-6">Carregando avaliações...</div>;
+    return (
+      <div className="h-full flex justify-center items-center">
+        <MoonLoader color="#085f60" />
+      </div>
+    );
   }
 
   const selectedResult = results?.find((r) => r.cycleId === selectedCycleId);

--- a/src/stores/useAutoevaluationStore.ts
+++ b/src/stores/useAutoevaluationStore.ts
@@ -68,7 +68,7 @@ export const useAutoevaluationStore = create<AutoevaluationStore>()(
         const filled = Object.values(state.responses).map(
           (response) => response.filled
         );
-
+        console.log("Filled responses:", filled);
         return filled.every(Boolean) && filled.length >= requiredCount;
       },
     }),

--- a/src/stores/useAutoevaluationStore.ts
+++ b/src/stores/useAutoevaluationStore.ts
@@ -68,7 +68,6 @@ export const useAutoevaluationStore = create<AutoevaluationStore>()(
         const filled = Object.values(state.responses).map(
           (response) => response.filled
         );
-        console.log("Filled responses:", filled);
         return filled.every(Boolean) && filled.length >= requiredCount;
       },
     }),


### PR DESCRIPTION
### what I did

- integrated results page
- add loader while defining evaluation page variant
- fixed list of colabs on reference tab

### how to test
- login as colab
- test 3 scenarios:
  - cycle open: evaluation page should show the form for evaluations and when you send the form it should redirect to results page (current cycle is not showed)
  - cycle in review: it should show results page (without current cycle)
  - cycle closed: it should show results page (with current cycle)