### PR TITLE
implement manager evaluation save logic, toast and readonly message display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^11.1.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -17,7 +17,7 @@ const TabsContent: React.FC<TabsContentProps> = ({
   contentByTab,
   itemClasses,
   className = "",
-  disabledTabs = [], // ← valor padrão vazio
+  disabledTabs = [],
 }) => {
   const isDisabled = (tab: string) => disabledTabs.includes(tab);
 

--- a/src/components/evaluation/ManagerCriterion.tsx
+++ b/src/components/evaluation/ManagerCriterion.tsx
@@ -16,6 +16,7 @@ interface ManagerCriterionProps {
   autoJustification: string;
   managerScore: number | null;
   managerJustification: string;
+  readonly?: boolean;
   setManagerScore: (score: number | null) => void;
   setManagerJustification: (text: string) => void;
   onFilledChange?: (isFilled: boolean) => void;
@@ -28,16 +29,18 @@ const ManagerCriterion = ({
   autoJustification,
   managerScore,
   managerJustification,
+  readonly,
   setManagerScore,
   setManagerJustification,
   onFilledChange,
 }: ManagerCriterionProps) => {
   const isFilled =
-    managerScore !== null && (managerJustification ?? "").trim().length > 0;
+    managerScore !== null &&
+    ((managerJustification || "") as string).trim().length > 0;
 
   useEffect(() => {
     onFilledChange?.(isFilled);
-  }, [isFilled]);
+  }, [isFilled, onFilledChange]);
 
   return (
     <Accordion type="single" collapsible>
@@ -74,9 +77,9 @@ const ManagerCriterion = ({
               <ReadonlyStars value={autoScore ?? 0} lowOpacity />
               <p className="text-xs mt-3 mb-1">Justificativa:</p>
               <textarea
-                className="bg-gray-100 w-full h-20 p-2 border border-gray-300 rounded-md resize-none"
+                className="w-full h-20 p-2 border border-gray-300 rounded-md resize-none bg-gray-100"
+                value={autoJustification}
                 readOnly
-                value={autoJustification ?? ""}
               />
             </div>
 
@@ -85,16 +88,26 @@ const ManagerCriterion = ({
               <p className="text-xs mb-1">
                 Sua avaliação de 1 a 5 com base no critério:
               </p>
-              <StarRating
-                value={managerScore ?? undefined}
-                onChange={setManagerScore}
-              />
+              {readonly ? (
+                <ReadonlyStars value={managerScore ?? 0} />
+              ) : (
+                <StarRating
+                  value={managerScore ?? undefined}
+                  onChange={setManagerScore}
+                />
+              )}
+
               <p className="text-xs mt-3 mb-1">Justifique sua nota:</p>
               <textarea
                 className="w-full h-20 p-2 border border-gray-300 rounded-md resize-none focus:outline-none bg-white"
                 placeholder="Justifique sua nota"
-                value={managerJustification ?? ""}
-                onChange={(e) => setManagerJustification(e.target.value)}
+                value={managerJustification}
+                onChange={
+                  readonly
+                    ? undefined
+                    : (e) => setManagerJustification(e.target.value)
+                }
+                readOnly={readonly}
               />
             </div>
           </div>

--- a/src/pages/gestor/ColaboradorDetails.tsx
+++ b/src/pages/gestor/ColaboradorDetails.tsx
@@ -22,6 +22,13 @@ interface EvaluationPerCycle {
   peerScores: number[];
 }
 
+interface ColaboradorInfo {
+  name: string;
+  position?: {
+    name: string;
+  };
+}
+
 const getEvaluationCycleStatus = (
   cycle: EvaluationPerCycle | { reviewDate: string; endDate: string }
 ): "aberto" | "emRevisao" | "finalizado" => {
@@ -46,7 +53,8 @@ const getAverage = (scores: number[]): number | undefined => {
 const ColaboradorDetails = () => {
   const { id: userId } = useParams();
   const [evaluations, setEvaluations] = useState<EvaluationPerCycle[]>([]);
-  const [colaboradorInfo, setColaboradorInfo] = useState<any>(null);
+  const [colaboradorInfo, setColaboradorInfo] =
+    useState<ColaboradorInfo | null>(null);
   const [activeTab, setActiveTab] = useState("Histórico");
 
   const now = useMemo(() => new Date(), []);

--- a/src/stores/useManagerEvaluationStore.ts
+++ b/src/stores/useManagerEvaluationStore.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export interface ManagerResponse {
+  score: number | null;
+  justification: string;
+  filled: boolean;
+}
+
+type EvaluationsByUser = Record<string, Record<string, ManagerResponse>>;
+
+interface ManagerEvaluationStore {
+  evaluations: EvaluationsByUser;
+  setResponse: (
+    userId: string,
+    criterionId: string,
+    response: ManagerResponse
+  ) => void;
+  getResponsesByUser: (userId: string) => Record<string, ManagerResponse>;
+  clearResponsesByUser: (userId: string) => void;
+}
+
+export const useManagerEvaluationStore = create(
+  persist<ManagerEvaluationStore>(
+    (set, get) => ({
+      evaluations: {},
+      setResponse: (userId, criterionId, response) =>
+        set((state) => ({
+          evaluations: {
+            ...state.evaluations,
+            [userId]: {
+              ...state.evaluations[userId],
+              [criterionId]: response,
+            },
+          },
+        })),
+      getResponsesByUser: (userId) => get().evaluations[userId] || {},
+      clearResponsesByUser: (userId) =>
+        set((state) => {
+          const newEvaluations = { ...state.evaluations };
+          delete newEvaluations[userId];
+          return { evaluations: newEvaluations };
+        }),
+    }),
+    {
+      name: "manager-evaluation-store",
+    }
+  )
+);


### PR DESCRIPTION
what was done:
- implemented evaluation saving logic
- enabled manager evaluation even when autoevaluation is not available
- displayed a readonly message when the manager has already submitted an evaluation
- added toast feedback on successful or failed submission
- fixed uppercase topic titles in criteria section

how to test:
1. go to gestor page, and go to the colaborador detail page where evaluation is not yet submitted
2. fill in all manager scores and justifications
3. click "submit" and check if toast appears and fields are reset 
4. reload the page and verify data is persisted 
5. test with a collaborator who has already been evaluated, you should see the readonly message instead of the form


