### PR TITLE
Resp/gestor

### DIFF
--- a/src/components/CollaboratorCard.tsx
+++ b/src/components/CollaboratorCard.tsx
@@ -11,7 +11,6 @@ interface CollaboratorCardProps {
   finalScore?: number | "-" | null;
   gestorCard?: boolean;
   brutalFactsCard?: boolean;
-  isComite?: boolean; 
   onClickArrow?: () => void;
 }
 
@@ -25,7 +24,6 @@ const CollaboratorCard: React.FC<CollaboratorCardProps> = ({
   finalScore,
   gestorCard = false,
   brutalFactsCard = false,
-  isComite = false,
   onClickArrow,
 }) => {
   const statusColorClass =
@@ -117,20 +115,11 @@ const CollaboratorCard: React.FC<CollaboratorCardProps> = ({
         )}
 
         <button
-          className={`p-2 rounded-full bg-transparent hover:bg-transparent focus:outline-none focus:ring-0 border-0
-            ${
-              isComite
-                ? "block xl1600:hidden" 
-                : "block" 
-            }
-            xl1600:text-white
-          `}
+          className="p-2 rounded-full bg-transparent hover:bg-transparent focus:outline-none focus:ring-0 border-0"
           onClick={onClickArrow}
-          aria-label="Expandir detalhes"
-          type="button"
         >
           <svg
-            className="w-5 h-5 text-current"
+            className="w-5 h-5 text-gray-500"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"

--- a/src/components/CollaboratorCard.tsx
+++ b/src/components/CollaboratorCard.tsx
@@ -12,6 +12,7 @@ interface CollaboratorCardProps {
   gestorCard?: boolean;
   brutalFactsCard?: boolean;
   onClickArrow?: () => void;
+  esconderSetaXL1600?: boolean; // prop para esconder seta em telas > 1600px
 }
 
 const CollaboratorCard: React.FC<CollaboratorCardProps> = ({
@@ -25,6 +26,7 @@ const CollaboratorCard: React.FC<CollaboratorCardProps> = ({
   gestorCard = false,
   brutalFactsCard = false,
   onClickArrow,
+  esconderSetaXL1600 = false,
 }) => {
   const statusColorClass =
     status === "Pendente"
@@ -115,7 +117,9 @@ const CollaboratorCard: React.FC<CollaboratorCardProps> = ({
         )}
 
         <button
-          className="p-2 rounded-full bg-transparent hover:bg-transparent focus:outline-none focus:ring-0 border-0"
+          className={`p-2 rounded-full bg-transparent hover:bg-transparent focus:outline-none focus:ring-0 border-0 ${
+            esconderSetaXL1600 ? "xl1600:hidden" : ""
+          }`}
           onClick={onClickArrow}
         >
           <svg

--- a/src/pages/comite/Dashboard.tsx
+++ b/src/pages/comite/Dashboard.tsx
@@ -343,6 +343,7 @@ const Comite: React.FC = () => {
                           assessment360={colab.assessment360}
                           managerScore={colab.managerScore}
                           finalScore={colab.finalScore}
+                          esconderSetaXL1600={true}
                         />
                       </div>
                       <div className="block xl1600:hidden">

--- a/src/pages/gestor/ColaboradorDetails.tsx
+++ b/src/pages/gestor/ColaboradorDetails.tsx
@@ -11,6 +11,7 @@ import ManagerEvaluationTab from "@/components/evaluation/ManagerEvaluationTab";
 import GoalCard from "@/components/GoalCard";
 import type { GoalData } from "@/types";
 
+
 interface EvaluationPerCycle {
   cycleId: string;
   name: string;
@@ -162,8 +163,8 @@ const ColaboradorDetails = () => {
       </div>
     ),
     Histórico: (
-      <div className="flex flex-col px-6 pt-2 gap-6">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+      <div className="flex flex-col px-0.5 pt-2 gap-6 lg:px-6">
+        <div className="grid grid-cols-1 phone:grid-cols-1 xl1600:grid-cols-3 gap-2">
           <DashboardStatCard
             type="currentScore"
             title="Nota atual"
@@ -224,7 +225,7 @@ const ColaboradorDetails = () => {
       </div>
     ),
     Objetivos: (
-      <div className="flex flex-col px-6 py-2 gap-4">
+      <div className="flex flex-col px-0.5 pt-2 gap-6 lg:px-6">
         <div className="flex justify-between items-center">
           <h3 className="font-bold">
             Acompanhamento {track === "FINANCEIRO" ? "de OKRs" : "do PDI"}
@@ -264,15 +265,15 @@ const ColaboradorDetails = () => {
             </p>
           </div>
         </div>
-        <div className="px-6">
+        <div className="overflow-x-auto max-w-full whitespace-nowrap scrollbar scrollbar-thumb-white scrollbar-track-white">
           <TabsContent
             activeTab={activeTab}
             onChangeTab={setActiveTab}
             tabs={TABS}
             itemClasses={{
-              Avaliação: "text-sm font-semibold px-6 py-3",
-              Histórico: "text-sm font-semibold px-6 py-3",
-              Objetivos: "text-sm font-semibold px-6 py-3",
+              Avaliação: "inline-block text-sm font-semibold px-6 py-3",
+              Histórico: "inline-block text-sm font-semibold px-6 py-3",
+              Objetivos: "inline-block text-sm font-semibold px-6 py-3",
             }}
             className="border-b border-gray-200 px-6"
             disabledTabs={cycleStatus !== "emRevisao" ? ["Avaliação"] : []}

--- a/src/pages/gestor/Colaboradores.tsx
+++ b/src/pages/gestor/Colaboradores.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SearchInput from "@/components/SearchInput";
-import StatusFilter from "@/components/StatusFilter";
 import CollaboratorCard from "@/components/CollaboratorCard";
 import { useGestorDashboardData } from "../gestor/hooks/useGestorDashboardData";
 
@@ -52,26 +51,33 @@ const ColaboradoresGestor = () => {
       statusFilter === "Todos" ? true : c.dynamicStatus === statusFilter
     );
 
+  const handleFilterChange = (filter: string) => {
+    if (filter === "Todos" || filter === "Pendente" || filter === "Finalizada") {
+      setStatusFilter(filter);
+    }
+  };
+
   return (
     <div className="bg-gray-100 font-sans">
       <div className="shadow-sm bg-white px-8 py-8 mb-6 max-w-[1700px] mx-auto">
-        <h1 className="text-2xl font-semibold text-gray-800">Colaboradores</h1>
+        <h1 className="text-2xl font-normal text-gray-800">Colaboradores</h1>
       </div>
 
-      <div className="px-4 sm:px-8 mb-4 flex items-center space-x-4 max-w-[1700px] mx-auto">
+      <div className="px-4 sm:px-8 mb-4 max-w-[1700px] mx-auto">
         <SearchInput
           value={search}
           onChange={setSearch}
           placeholder="Buscar por colaboradores"
-          className="flex-grow w-full sm:w-[1550px]"
+          className="w-full"
+          filterOptions={["Todos", "Pendente", "Finalizada"]}
+          initialFilter="Todos"
+          onFilterChange={handleFilterChange}
         />
-        <StatusFilter value={statusFilter} onChange={setStatusFilter} />
       </div>
 
       <div className="px-4 sm:px-8 space-y-4 w-full max-w-full pb-8">
         {processedCollaborators.map((c) => {
           if (!isMobileLayout) {
-            // Desktop: mostrar o card original
             return (
               <CollaboratorCard
                 key={c.id}
@@ -87,7 +93,6 @@ const ColaboradoresGestor = () => {
             );
           }
 
-          // Mobile: empilhar nome, profissão, status + notas lado a lado + seta
           return (
             <div
               key={c.id}

--- a/src/pages/gestor/Colaboradores.tsx
+++ b/src/pages/gestor/Colaboradores.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SearchInput from "@/components/SearchInput";
 import StatusFilter from "@/components/StatusFilter";
@@ -10,9 +10,20 @@ const ColaboradoresGestor = () => {
   const [statusFilter, setStatusFilter] = useState<
     "Todos" | "Pendente" | "Finalizada"
   >("Todos");
+  const [windowWidth, setWindowWidth] = useState(
+    typeof window !== "undefined" ? window.innerWidth : 1400
+  );
 
   const { collaborators, cycleStatus } = useGestorDashboardData();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleResize = () => setWindowWidth(window.innerWidth);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const isMobileLayout = windowWidth < 1215;
 
   const filtered = collaborators.filter(
     (c) =>
@@ -20,10 +31,31 @@ const ColaboradoresGestor = () => {
       c.position.toLowerCase().includes(search.toLowerCase())
   );
 
+  const processedCollaborators = filtered
+    .map((c) => {
+      let dynamicStatus: "Pendente" | "Finalizada";
+
+      if (cycleStatus === "aberto") {
+        dynamicStatus = c.autoAssessment !== null ? "Finalizada" : "Pendente";
+      } else if (cycleStatus === "emRevisao") {
+        dynamicStatus = c.managerScore !== null ? "Finalizada" : "Pendente";
+      } else {
+        dynamicStatus = c.comiteScore !== null ? "Finalizada" : "Pendente";
+      }
+
+      return {
+        ...c,
+        dynamicStatus,
+      };
+    })
+    .filter((c) =>
+      statusFilter === "Todos" ? true : c.dynamicStatus === statusFilter
+    );
+
   return (
     <div className="bg-gray-100 font-sans">
       <div className="shadow-sm bg-white px-8 py-8 mb-6 max-w-[1700px] mx-auto">
-        <h1 className="text-2xl font-normal text-gray-800">Colaboradores</h1>
+        <h1 className="text-2xl font-semibold text-gray-800">Colaboradores</h1>
       </div>
 
       <div className="px-4 sm:px-8 mb-4 flex items-center space-x-4 max-w-[1700px] mx-auto">
@@ -37,44 +69,87 @@ const ColaboradoresGestor = () => {
       </div>
 
       <div className="px-4 sm:px-8 space-y-4 w-full max-w-full pb-8">
-        {filtered
-          .map((c) => {
-            let dynamicStatus: "Pendente" | "Finalizada";
+        {processedCollaborators.map((c) => {
+          if (!isMobileLayout) {
+            // Desktop: mostrar o card original
+            return (
+              <CollaboratorCard
+                key={c.id}
+                name={c.name}
+                role={c.position}
+                status={c.dynamicStatus}
+                autoAssessment={c.autoAssessment}
+                managerScore={c.managerScore}
+                finalScore={cycleStatus === "finalizado" ? c.comiteScore : undefined}
+                gestorCard
+                onClickArrow={() => navigate(`/app/gestor/colaboradores/${c.id}`)}
+              />
+            );
+          }
 
-            if (cycleStatus === "aberto") {
-              dynamicStatus =
-                c.autoAssessment !== null ? "Finalizada" : "Pendente";
-            } else if (cycleStatus === "emRevisao") {
-              dynamicStatus =
-                c.managerScore !== null ? "Finalizada" : "Pendente";
-            } else {
-              dynamicStatus =
-                c.comiteScore !== null ? "Finalizada" : "Pendente";
-            }
-
-            return {
-              ...c,
-              dynamicStatus,
-            };
-          })
-          .filter((c) =>
-            statusFilter === "Todos" ? true : c.dynamicStatus === statusFilter
-          )
-          .map((c) => (
-            <CollaboratorCard
+          // Mobile: empilhar nome, profissão, status + notas lado a lado + seta
+          return (
+            <div
               key={c.id}
-              name={c.name}
-              role={c.position}
-              status={c.dynamicStatus}
-              autoAssessment={c.autoAssessment}
-              managerScore={c.managerScore}
-              finalScore={
-                cycleStatus === "finalizado" ? c.comiteScore : undefined
-              }
-              gestorCard
-              onClickArrow={() => navigate(`/app/gestor/colaboradores/${c.id}`)}
-            />
-          ))}
+              className="bg-white rounded-lg shadow p-4 max-w-full cursor-pointer"
+              onClick={() => navigate(`/app/gestor/colaboradores/${c.id}`)}
+              style={{ minWidth: 320 }}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="flex items-center justify-center w-12 h-12 rounded-full bg-gray-300 text-white font-semibold text-lg select-none">
+                    {c.name
+                      .split(" ")
+                      .map((n) => n[0])
+                      .join("")
+                      .toUpperCase()}
+                  </div>
+                  <div className="flex flex-col">
+                    <p className="font-semibold text-gray-900">{c.name}</p>
+                    <p className="text-sm text-gray-600">{c.position}</p>
+                    <p
+                      className={`mt-1 text-xs font-medium ${
+                        c.dynamicStatus === "Finalizada"
+                          ? "text-green-600"
+                          : "text-yellow-600"
+                      }`}
+                    >
+                      {c.dynamicStatus}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="text-gray-700">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-6 w-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </div>
+              </div>
+
+              <div className="flex justify-center gap-8 mt-4">
+                <div className="px-2 py-1 text-center">
+                  <p className="text-sm text-gray-500">Autoavaliação</p>
+                  <p className="font-semibold text-gray-900">
+                    {c.autoAssessment !== null ? c.autoAssessment.toFixed(1) : "-"}
+                  </p>
+                </div>
+                <div className="px-2 py-1 text-center">
+                  <p className="text-sm text-gray-500">Gestor</p>
+                  <p className="font-semibold text-gray-900">
+                    {c.managerScore !== null ? c.managerScore.toFixed(1) : "-"}
+                  </p>
+                </div>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/gestor/Dashboard.tsx
+++ b/src/pages/gestor/Dashboard.tsx
@@ -1,3 +1,4 @@
+import React from "react"; // <-- Importação React explícita
 import { Link, useNavigate } from "react-router-dom";
 import { Star, Users, FileText } from "lucide-react";
 
@@ -45,6 +46,18 @@ const DashboardGestor = () => {
   ).length;
   const pendingAutoEvaluations = collaborators.length - autoEvaluated;
 
+  const [windowWidth, setWindowWidth] = React.useState(
+    typeof window !== "undefined" ? window.innerWidth : 1400
+  );
+
+  React.useEffect(() => {
+    const handleResize = () => setWindowWidth(window.innerWidth);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const isMobileLayout = windowWidth < 1215;
+
   return (
     <div className="flex flex-col h-full p-6">
       <div className="flex justify-between items-center mb-4">
@@ -68,7 +81,7 @@ const DashboardGestor = () => {
             }}
             isGestor
             onClick={() =>
-              cycleStatus == "finalizado"
+              cycleStatus === "finalizado"
                 ? navigate(`/app/gestor/brutalfacts`)
                 : navigate(`/app/gestor/colaboradores/`)
             }
@@ -209,24 +222,96 @@ const DashboardGestor = () => {
                   collaborator.comiteScore !== null ? "Finalizada" : "Pendente";
               }
 
+              if (!isMobileLayout) {
+                return (
+                  <CollaboratorCard
+                    key={collaborator.id}
+                    name={collaborator.name}
+                    role={collaborator.position}
+                    status={dynamicStatus}
+                    autoAssessment={collaborator.autoAssessment}
+                    managerScore={collaborator.managerScore}
+                    finalScore={
+                      cycleStatus === "finalizado"
+                        ? collaborator.comiteScore
+                        : undefined
+                    }
+                    gestorCard
+                    onClickArrow={() =>
+                      navigate(`/app/gestor/colaboradores/${collaborator.id}`)
+                    }
+                  />
+                );
+              }
+
               return (
-                <CollaboratorCard
+                <div
                   key={collaborator.id}
-                  name={collaborator.name}
-                  role={collaborator.position}
-                  status={dynamicStatus}
-                  autoAssessment={collaborator.autoAssessment}
-                  managerScore={collaborator.managerScore}
-                  finalScore={
-                    cycleStatus === "finalizado"
-                      ? collaborator.comiteScore
-                      : undefined
-                  }
-                  gestorCard
-                  onClickArrow={() =>
+                  className="bg-white rounded-lg shadow p-4 max-w-full cursor-pointer"
+                  onClick={() =>
                     navigate(`/app/gestor/colaboradores/${collaborator.id}`)
                   }
-                />
+                  style={{ minWidth: 320 }}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                      <div className="flex items-center justify-center w-12 h-12 rounded-full bg-gray-300 text-white font-semibold text-lg select-none">
+                        {collaborator.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")
+                          .toUpperCase()}
+                      </div>
+                      <div className="flex flex-col">
+                        <p className="font-semibold text-gray-900">
+                          {collaborator.name}
+                        </p>
+                        <p className="text-sm text-gray-600">{collaborator.position}</p>
+                        <p
+                          className={`mt-1 text-xs font-medium ${
+                            dynamicStatus === "Finalizada"
+                              ? "text-green-600"
+                              : "text-yellow-600"
+                          }`}
+                        >
+                          {dynamicStatus}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="text-gray-700">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-6 w-6"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                      </svg>
+                    </div>
+                  </div>
+
+                  <div className="flex justify-center gap-8 mt-4">
+                    <div className="px-2 py-1 text-center">
+                      <p className="text-sm text-gray-500">Autoavaliação</p>
+                      <p className="font-semibold text-gray-900">
+                        {collaborator.autoAssessment !== null
+                          ? collaborator.autoAssessment.toFixed(1)
+                          : "-"}
+                      </p>
+                    </div>
+                    <div className="px-2 py-1 text-center">
+                      <p className="text-sm text-gray-500">Gestor</p>
+                      <p className="font-semibold text-gray-900">
+                        {collaborator.managerScore !== null
+                          ? collaborator.managerScore.toFixed(1)
+                          : "-"}
+                      </p>
+                    </div>
+                  </div>
+                </div>
               );
             })}
           </div>

--- a/src/pages/gestor/Dashboard.tsx
+++ b/src/pages/gestor/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from "react"; // <-- Importação React explícita
+import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Star, Users, FileText } from "lucide-react";
 

--- a/src/pages/rh/Colaboradores.tsx
+++ b/src/pages/rh/Colaboradores.tsx
@@ -202,7 +202,7 @@ const Colaboradores = () => {
                 >
                   <div className="max-w-full">
                     <div className="hidden xl1600:block">
-                      <CollaboratorCard {...colab} />
+                      <CollaboratorCard {...colab} esconderSetaXL1600={true} />
                     </div>
                     <div className="block xl1600:hidden bg-white rounded-lg shadow p-4 flex-col min-w-[320px]">
                       <div className="flex items-center gap-4">

--- a/src/pages/rh/Colaboradores.tsx
+++ b/src/pages/rh/Colaboradores.tsx
@@ -80,13 +80,16 @@ const Colaboradores = () => {
       try {
         const token = localStorage.getItem("token");
         if (!token) throw new Error("Token não encontrado. Faça login novamente.");
+
         const response = await fetch("http://localhost:3000/users", {
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
           },
         });
+
         if (!response.ok) throw new Error("Erro ao buscar colaboradores.");
+
         const data: ApiResponse = await response.json();
 
         const colaboradoresFiltrados: Colaborador[] = data.usuarios
@@ -97,14 +100,17 @@ const Colaboradores = () => {
             const assessment360 = calcularMedia360(todasPeerScores);
             const autoAssessment = scoreAtual?.selfScore ?? null;
             const managerScore = scoreAtual?.leaderScore ?? null;
+
             const status =
               scoreAtual && scoreAtual.finalScore !== null && scoreAtual.finalScore !== undefined
                 ? "Finalizada"
                 : "Pendente";
+
             const finalScore =
               status === "Finalizada" && scoreAtual && scoreAtual.finalScore !== null
                 ? Number(scoreAtual.finalScore.toFixed(1))
                 : "-";
+
             return {
               id: u.id,
               name: u.name,
@@ -125,6 +131,7 @@ const Colaboradores = () => {
         setLoading(false);
       }
     }
+
     fetchCollaborators();
   }, []);
 
@@ -132,7 +139,9 @@ const Colaboradores = () => {
     const matchesSearch =
       colab.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
       colab.role.toLowerCase().includes(searchTerm.toLowerCase());
+
     const matchesStatus = statusFilter === "Todos" || colab.status === statusFilter;
+
     return matchesSearch && matchesStatus;
   });
 
@@ -153,8 +162,9 @@ const Colaboradores = () => {
   return (
     <div className="bg-gray-100 font-sans min-h-screen">
       <div className="shadow-sm bg-white px-4 md:px-8 py-8 mb-6 max-w-[1700px] mx-auto w-full">
-        <h1 className="text-2xl font-normal text-gray-800">Colaboradores</h1>
+        <h1 className="text-2xl font-semibold text-gray-800">Colaboradores</h1>
       </div>
+
       <div className="px-4 md:px-8 mb-8 flex flex-wrap gap-4 max-w-[1700px] mx-auto w-full">
         <div className="flex-grow min-w-[200px]">
           <SearchInput
@@ -164,25 +174,35 @@ const Colaboradores = () => {
             className="w-full"
             filterOptions={["Todos", "Finalizada", "Pendente"]}
             initialFilter="Todos"
-            onFilterChange={(val) => setStatusFilter(val as "Todos" | "Finalizada" | "Pendente")}
+            onFilterChange={(val) =>
+              setStatusFilter(val as "Todos" | "Finalizada" | "Pendente")
+            }
           />
         </div>
       </div>
+
       <div className="px-4 md:px-8 space-y-4 max-w-[1700px] mx-auto w-full pb-8">
-        {loading && <p className="text-center text-gray-600">Carregando colaboradores...</p>}
+        {loading && (
+          <p className="text-center text-gray-600">Carregando colaboradores...</p>
+        )}
         {error && <p className="text-center text-red-600">{error}</p>}
         {!loading && !error && filteredCollaborators.length === 0 && (
           <p className="text-gray-600 text-center mt-10">Nenhum colaborador encontrado.</p>
         )}
+
         {!loading &&
           !error &&
           filteredCollaborators.map((colab) => {
             if (!isMobileLayout) {
               return (
-                <div key={colab.id} className="w-full overflow-x-auto" style={{ minWidth: 320 }}>
+                <div
+                  key={colab.id}
+                  className="w-full overflow-x-auto"
+                  style={{ minWidth: 320 }}
+                >
                   <div className="max-w-full">
                     <div className="hidden xl1600:block">
-                      <CollaboratorCard {...colab} isComite={colab.role.toLowerCase() === "comite"} />
+                      <CollaboratorCard {...colab} />
                     </div>
                     <div className="block xl1600:hidden bg-white rounded-lg shadow p-4 flex-col min-w-[320px]">
                       <div className="flex items-center gap-4">
@@ -198,13 +218,16 @@ const Colaboradores = () => {
                           <p className="text-sm text-gray-600">{colab.role}</p>
                           <p
                             className={`mt-1 text-xs font-medium ${
-                              colab.status === "Finalizada" ? "text-green-600" : "text-yellow-600"
+                              colab.status === "Finalizada"
+                                ? "text-green-600"
+                                : "text-yellow-600"
                             }`}
                           >
                             {colab.status}
                           </p>
                         </div>
                       </div>
+
                       <div className="flex flex-col lg:flex-row justify-between gap-6 text-center mt-4">
                         <div className="px-2 py-1 -mb-4">
                           <p className="text-sm text-gray-500">Autoavaliação</p>
@@ -217,13 +240,17 @@ const Colaboradores = () => {
                         <div className="px-2 py-1 -mb-4">
                           <p className="text-sm text-gray-500">Avaliação 360</p>
                           <p className="font-semibold text-gray-900">
-                            {colab.assessment360 !== null ? Number(colab.assessment360).toFixed(1) : "-"}
+                            {colab.assessment360 !== null
+                              ? Number(colab.assessment360).toFixed(1)
+                              : "-"}
                           </p>
                         </div>
                         <div className="px-2 py-1 -mb-4">
                           <p className="text-sm text-gray-500">Gestor</p>
                           <p className="font-semibold text-gray-900">
-                            {colab.managerScore !== null ? Number(colab.managerScore).toFixed(1) : "-"}
+                            {colab.managerScore !== null
+                              ? Number(colab.managerScore).toFixed(1)
+                              : "-"}
                           </p>
                         </div>
                         <div className="px-2 py-1">
@@ -240,7 +267,11 @@ const Colaboradores = () => {
             const isExpanded = expandedIds.has(colab.id);
 
             return (
-              <div key={colab.id} className="w-full overflow-x-auto" style={{ minWidth: 320 }}>
+              <div
+                key={colab.id}
+                className="w-full overflow-x-auto"
+                style={{ minWidth: 320 }}
+              >
                 <div className="max-w-full bg-white rounded-lg shadow p-4 flex flex-col">
                   <div
                     className="flex items-center justify-between cursor-pointer"
@@ -259,7 +290,9 @@ const Colaboradores = () => {
                         <p className="text-sm text-gray-600">{colab.role}</p>
                         <p
                           className={`mt-1 text-xs font-medium ${
-                            colab.status === "Finalizada" ? "text-green-600" : "text-yellow-600"
+                            colab.status === "Finalizada"
+                              ? "text-green-600"
+                              : "text-yellow-600"
                           }`}
                         >
                           {colab.status}
@@ -286,7 +319,9 @@ const Colaboradores = () => {
 
                   <div
                     className={`flex flex-col gap-4 text-center mt-4 transition-[max-height,opacity,padding] duration-300 ease-in-out overflow-hidden ${
-                      isExpanded ? "max-h-[500px] opacity-100 pt-4 pb-4" : "max-h-0 opacity-0 pt-0 pb-0"
+                      isExpanded
+                        ? "max-h-[500px] opacity-100 pt-4 pb-4"
+                        : "max-h-0 opacity-0 pt-0 pb-0"
                     }`}
                     aria-expanded={isExpanded}
                   >


### PR DESCRIPTION
- ColaboradorCard: reverted to the original implementation and added a prop to disable the arrow on pages where it's not needed.
- Responsiveness: adjusted the Colaborador, Gestor Dashboard, and Colaborador Details screens for better display on different screen sizes.
- Comitê and RH: fixed the Comitê Dashboard and RH Colaboradores pages by using the new prop to hide the card arrow.