### PR TITLE
changed the way time is being shown on notification creation form (rh)

### DIFF
--- a/src/components/notification/NotificationForm.tsx
+++ b/src/components/notification/NotificationForm.tsx
@@ -309,20 +309,17 @@ export const NotificationForm = ({
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 Horário programado
               </label>
-              <select
-                value={scheduledTime}
-                onChange={(e) => setScheduledTime(e.target.value)}
-                className="w-full border border-gray-300 rounded-lg p-3 text-sm bg-white text-black focus:outline-none focus:ring-2 focus:ring-emerald-600 shadow-sm"
-              >
-                {scheduleOptions[notificationType].map((h) => (
-                  <option key={h} value={h}>
-                    {h}
-                  </option>
-                ))}
-              </select>
+              <p className="text-sm text-gray-800 border border-gray-200 rounded-lg bg-gray-50 px-3 py-2">
+                Notificações do tipo{" "}
+                <span className="font-semibold">
+                  {notificationTypes.find((t) => t.value === notificationType)
+                    ?.label ?? notificationType}
+                </span>{" "}
+                serão enviadas às{" "}
+                <span className="font-semibold">{scheduledTime}</span>.
+              </p>
             </div>
           )}
-
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
               Dias de antecedência do evento


### PR DESCRIPTION
<img width="531" height="144" alt="Screenshot from 2025-07-15 17-37-17" src="https://github.com/user-attachments/assets/6652184c-9593-4b58-a0a6-dfa159e6e84e" />


what was done

-     replaced scheduled time select with static info text
-     shows the time configured for the selected notification type
-     prevents user from editing backend-controlled time

how to test

1.     go to create or edit notification (rh)
2.     select a type that has predefined schedule
3.     check if message like “notifications of type X will be sent at HH:MM” appears