### PR TITLE
fix/growth-cards

### DIFF
--- a/src/pages/gestor/Dashboard.tsx
+++ b/src/pages/gestor/Dashboard.tsx
@@ -173,11 +173,9 @@ const DashboardGestor = () => {
                     ? "Ainda não há colaboradores com histórico suficiente para mostrar crescimento."
                     : `${
                         growth >= 0 ? "Crescimento" : "Queda"
-                      } de ${growth.toFixed(
-                        1
-                      )} em relação ao ciclo anterior. (baseado em ${growthBaseCount} colaborador${
+                      }  com base em ${growthBaseCount} colaborador${
                         growthBaseCount > 1 ? "es" : ""
-                      })`
+                      }`
                 }
                 value={!hasGrowthData ? "-" : growth}
               />


### PR DESCRIPTION
fix: unify growth calculation and display
-     refactored evolution.tsx to handle missing final scores safely
-     added fallback message when no comparison is possible
-     ensured same growth format used in gestor pages (dashboardgestor and brutalfacts)
how to test:
1.     check evolution page: growth should be shown only if both cycles have final scores
2.     verify same formatting in gestor dashboard and brutal facts pages
3.     ensure no NaN or Infinity appears anywhere